### PR TITLE
#309 VOC ADMIN API ( 조회 파라미터 reply 디폴트값 해제, PageInfo 정보 추가, 관리자 답장 데이…

### DIFF
--- a/src/main/generated/fotcamp/finhub/common/domain/QFeedback.java
+++ b/src/main/generated/fotcamp/finhub/common/domain/QFeedback.java
@@ -21,6 +21,8 @@ public class QFeedback extends EntityPathBase<Feedback> {
 
     public final QBaseEntity _super = new QBaseEntity(this);
 
+    public final StringPath adminResponse = createString("adminResponse");
+
     public final StringPath appVersion = createString("appVersion");
 
     //inherited

--- a/src/main/java/fotcamp/finhub/admin/controller/AdminController.java
+++ b/src/main/java/fotcamp/finhub/admin/controller/AdminController.java
@@ -514,7 +514,7 @@ public class AdminController {
     @Operation(summary = "VOC 목록 조회", description = "페이지 방식 적용, 파라미터로 reply=T 혹은 F로 답장했던 목록 혹은 답장안한 목록 조회 가능")
     public ResponseEntity<ApiResponseWrapper> vocList(@RequestParam(value = "page", defaultValue = "1") int page,
                                                       @RequestParam(value = "size", defaultValue = "10") int size,
-                                                      @RequestParam(value = "reply", defaultValue = "F") String reply
+                                                      @RequestParam(value = "reply", required = false) String reply
     ){
         return adminService.vocList(page, size, reply);
     }

--- a/src/main/java/fotcamp/finhub/admin/dto/process/VocDetailProcessDto.java
+++ b/src/main/java/fotcamp/finhub/admin/dto/process/VocDetailProcessDto.java
@@ -15,11 +15,12 @@ public class VocDetailProcessDto {
     private String fileUrl2;
     private String fileUrl3;
     private String fileUrl4;
+    private String adminResponse;
     private String reply;
 
 
     @Builder
-    public VocDetailProcessDto(Long feedbackId, String userAgent, String appVersion, String email, String context, String fileUrl1, String fileUrl2, String fileUrl3, String fileUrl4, String reply) {
+    public VocDetailProcessDto(Long feedbackId, String userAgent, String appVersion, String email, String context, String fileUrl1, String fileUrl2, String fileUrl3, String fileUrl4, String adminResponse, String reply) {
         this.feedbackId = feedbackId;
         this.userAgent = userAgent;
         this.appVersion = appVersion;
@@ -29,6 +30,7 @@ public class VocDetailProcessDto {
         this.fileUrl2 = fileUrl2;
         this.fileUrl3 = fileUrl3;
         this.fileUrl4 = fileUrl4;
+        this.adminResponse = adminResponse;
         this.reply = reply;
     }
 }

--- a/src/main/java/fotcamp/finhub/admin/dto/process/VocListPageInfoProcessDto.java
+++ b/src/main/java/fotcamp/finhub/admin/dto/process/VocListPageInfoProcessDto.java
@@ -1,0 +1,13 @@
+package fotcamp.finhub.admin.dto.process;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+public record VocListPageInfoProcessDto(
+        int currentPage,
+        int totalPages,
+        int pageSize,
+        long totalElements
+) {
+}

--- a/src/main/java/fotcamp/finhub/admin/dto/response/VocListResponseDto.java
+++ b/src/main/java/fotcamp/finhub/admin/dto/response/VocListResponseDto.java
@@ -1,8 +1,9 @@
 package fotcamp.finhub.admin.dto.response;
 
+import fotcamp.finhub.admin.dto.process.VocListPageInfoProcessDto;
 import fotcamp.finhub.admin.dto.process.VocListProcessDto;
 
 import java.util.List;
 
-public record VocListResponseDto(List<VocListProcessDto> vocList) {
+public record VocListResponseDto(List<VocListProcessDto> vocList, VocListPageInfoProcessDto pageInfo) {
 }

--- a/src/main/java/fotcamp/finhub/admin/service/AdminService.java
+++ b/src/main/java/fotcamp/finhub/admin/service/AdminService.java
@@ -1255,13 +1255,26 @@ public class AdminService {
 
     public ResponseEntity<ApiResponseWrapper> vocList(int page, int size, String reply){
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdTime"));
-        Page<Feedback> feedbackList = feedbackRepository.findFeedbacksByReply(reply, pageable);
+        Page<Feedback> feedbackList;
+        if(reply != null){
+            feedbackList = feedbackRepository.findFeedbacksByReply(reply, pageable);
+        }
+        else{
+            feedbackList = feedbackRepository.findAll(pageable);
+        }
         List<VocListProcessDto> vocDetailProcessDtoList = feedbackList.stream().map(feedback -> VocListProcessDto.builder()
                 .feedbackId(feedback.getId())
                 .email(feedback.getEmail())
                 .context(feedback.getFeedback())
                 .reply(feedback.getReply()).build()).toList();
-        return ResponseEntity.ok(ApiResponseWrapper.success(new VocListResponseDto(vocDetailProcessDtoList)));
+
+        VocListPageInfoProcessDto pageInfo = VocListPageInfoProcessDto.builder()
+                .currentPage(page)
+                .totalPages(feedbackList.getTotalPages())
+                .pageSize(size)
+                .totalElements(feedbackList.getTotalElements())
+                .build();
+        return ResponseEntity.ok(ApiResponseWrapper.success(new VocListResponseDto(vocDetailProcessDtoList, pageInfo)));
     }
 
     public ResponseEntity<ApiResponseWrapper> vocDetail(Long id){
@@ -1276,6 +1289,7 @@ public class AdminService {
                 .fileUrl2(checkIfNullFileUrl(feedback.getFileUrl2()))
                 .fileUrl3(checkIfNullFileUrl(feedback.getFileUrl3()))
                 .fileUrl4(checkIfNullFileUrl(feedback.getFileUrl4()))
+                .adminResponse(feedback.getAdminResponse())
                 .reply(feedback.getReply())
                 .build();
         return ResponseEntity.ok(ApiResponseWrapper.success(new VocDetailResponseDto(vocDetailProcessDto)));
@@ -1294,7 +1308,7 @@ public class AdminService {
         } catch (MessagingException exception){
             return ResponseEntity.badRequest().body(ApiResponseWrapper.fail("메일 전송 실패"));
         }
-        feedback.updateFeedback("T");
+        feedback.updateFeedback("T", dto.text());
         return ResponseEntity.ok(ApiResponseWrapper.success());
     }
 }

--- a/src/main/java/fotcamp/finhub/common/domain/Feedback.java
+++ b/src/main/java/fotcamp/finhub/common/domain/Feedback.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
 import lombok.AccessLevel;
 
 import lombok.Builder;
@@ -26,7 +27,10 @@ public class Feedback extends BaseEntity{
     private String fileUrl2;
     private String fileUrl3;
     private String fileUrl4;
+    @Lob
     private String feedback;
+    @Lob
+    private String adminResponse;
     private String reply;
 
     @Builder
@@ -39,10 +43,12 @@ public class Feedback extends BaseEntity{
         this.fileUrl3 = fileUrl3;
         this.fileUrl4 = fileUrl4;
         this.feedback = feedback;
+        this.adminResponse = null;
         this.reply = "F";
     }
 
-    public void updateFeedback(String reply){
+    public void updateFeedback(String reply, String text){
+        this.adminResponse = text;
         this.reply = reply;
     }
 


### PR DESCRIPTION
…터 컬럼 저장 ) 리팩토링

## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] 정기반영
- [ ] ETC

## 📝 PR 설명

<!-- PR 설명 -->
#309 
## 관련된 이슈 넘버

<!-- close #1 -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- 조회api reply 파라미터 디폴트값 해제, T&F 전체조회 가능
- 페이지네이션 메타데이터 제공
- 관리자 응답 데이터 컬럼 저장

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
<img width="266" alt="image" src="https://github.com/user-attachments/assets/25fa623c-a9e6-47d9-b819-32bf8724faeb">

<img width="175" alt="image" src="https://github.com/user-attachments/assets/dc9ee57e-3884-4ec1-a03b-0e97bcd6dede">
