### PR TITLE
#317 uuid 필드 추가, 유저 구별 프로세스 리팩토링, jwt 클레임 값 수정

### DIFF
--- a/.github/workflows/pr_merged.yml
+++ b/.github/workflows/pr_merged.yml
@@ -1,0 +1,34 @@
+name: notify pr merged
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - develop
+
+jobs:
+  Notify:
+    runs-on: [ubuntu-latest]
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Send Slack notification
+        id: slack
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "SLACK PR 알림",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*${{ github.repository }}* PR 머지되었습니다👍\n이제 배포가 진행됩니다. 배포 로그를 확인해주세요.\n<${{ github.event.pull_request.html_url }}|PR 확인하러 가기>\nRegistered by *${{ github.event.pull_request.user.login }}*\n머지한 사람: *${{ github.event.pull_request.merged_by.login }}*"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/remind-unmerged-pr.yml
+++ b/.github/workflows/remind-unmerged-pr.yml
@@ -1,0 +1,76 @@
+name: Remind Unmerged PRs
+
+on:
+  schedule:
+    # 매일 한국 시간(KST) 오전 9시 (UTC 기준 0시)
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  Remind:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: List open PRs
+        id: list_prs
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: pullRequests } = await github.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+
+            const unmergedPRs = pullRequests.filter(pr => !pr.merged_at);
+            const prList = unmergedPRs.map(pr => `- <${pr.html_url}|${pr.title}> by ${pr.user.login}`).join('\n');
+
+            return {
+              count: unmergedPRs.length,
+              prList
+            };
+          result-encoding: string
+          result-type: json
+
+      - name: Send Slack notification (with PRs)
+        if: steps.list_prs.outputs.count != '0'
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "PR Reminder: There are ${{ steps.list_prs.outputs.count }} open PRs that have not been merged.",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*${{ github.repository }}* 리포지토리의 총 ${{ steps.list_prs.outputs.count }}개의 머지 리퀘스트가 관심을 기다리고 있어요:\n\n${{ steps.list_prs.outputs.prList }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+      - name: Send Slack notification (no PRs)
+        if: steps.list_prs.outputs.count == '0'
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "No open PRs in the repository!",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*${{ github.repository }}*에 남아있는 PR이 없어서 Finhub 비서는 행복해요 😄"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/remind-unmerged-pr.yml
+++ b/.github/workflows/remind-unmerged-pr.yml
@@ -26,12 +26,8 @@ jobs:
             const unmergedPRs = pullRequests.filter(pr => !pr.merged_at);
             const prList = unmergedPRs.map(pr => `- <${pr.html_url}|${pr.title}> by ${pr.user.login}`).join('\n');
 
-            return {
-              count: unmergedPRs.length,
-              prList
-            };
-          result-encoding: string
-          result-type: json
+            core.setOutput('count', unmergedPRs.length.toString());
+            core.setOutput('prList', prList.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n'));
 
       - name: Send Slack notification (with PRs)
         if: steps.list_prs.outputs.count != '0'

--- a/.github/workflows/remind-unmerged-pr.yml
+++ b/.github/workflows/remind-unmerged-pr.yml
@@ -3,7 +3,7 @@ name: Remind Unmerged PRs
 on:
   schedule:
     # 매일 한국 시간(KST) 오전 9시 (UTC 기준 0시)
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const { data: pullRequests } = await github.pulls.list({
+            const { data: pullRequests } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open'

--- a/src/main/generated/fotcamp/finhub/admin/domain/QManager.java
+++ b/src/main/generated/fotcamp/finhub/admin/domain/QManager.java
@@ -23,6 +23,8 @@ public class QManager extends EntityPathBase<Manager> {
 
     public final StringPath fcmToken = createString("fcmToken");
 
+    public final StringPath managerUuid = createString("managerUuid");
+
     public final NumberPath<Long> memberId = createNumber("memberId", Long.class);
 
     public final StringPath name = createString("name");

--- a/src/main/generated/fotcamp/finhub/common/domain/QMember.java
+++ b/src/main/generated/fotcamp/finhub/common/domain/QMember.java
@@ -36,6 +36,8 @@ public class QMember extends EntityPathBase<Member> {
 
     public final ListPath<MemberScrap, QMemberScrap> memberScrapList = this.<MemberScrap, QMemberScrap>createList("memberScrapList", MemberScrap.class, QMemberScrap.class, PathInits.DIRECT2);
 
+    public final StringPath memberUuid = createString("memberUuid");
+
     public final StringPath name = createString("name");
 
     public final StringPath nickname = createString("nickname");

--- a/src/main/java/fotcamp/finhub/admin/domain/Manager.java
+++ b/src/main/java/fotcamp/finhub/admin/domain/Manager.java
@@ -32,6 +32,9 @@ public class Manager {
     @Column(name = "FCM_TOKEN")
     private String fcmToken;
 
+    @Column(name = "ADMIN_UUID")
+    private String managerUuid;
+
     @Builder
     public Manager(Long memberId, String email, String name, String password, String fcmToken) {
         this.memberId = memberId;
@@ -40,6 +43,7 @@ public class Manager {
         this.password = password;
         this.role = RoleType.ROLE_BE;
         this.fcmToken = fcmToken;
+        this.managerUuid = "FOTCAMP";
     }
 
     public void updateFcmToken(String token){

--- a/src/main/java/fotcamp/finhub/admin/repository/ManagerRepository.java
+++ b/src/main/java/fotcamp/finhub/admin/repository/ManagerRepository.java
@@ -1,7 +1,6 @@
 package fotcamp.finhub.admin.repository;
 
 import fotcamp.finhub.admin.domain.Manager;
-import fotcamp.finhub.common.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +12,7 @@ import java.util.Optional;
 @Repository
 public interface ManagerRepository extends JpaRepository<Manager, Long> {
     Optional<Manager> findByEmail(String email);
+    Optional<Manager> findByManagerUuid(String uuid);
 
     @Query("SELECT m FROM Manager m WHERE m.email IN :emails")
     List<Manager> findByPushYnAndEmails(@Param("emails") List<String> emails);

--- a/src/main/java/fotcamp/finhub/admin/service/AdminService.java
+++ b/src/main/java/fotcamp/finhub/admin/service/AdminService.java
@@ -1305,11 +1305,11 @@ public class AdminService {
     public ResponseEntity<ApiResponseWrapper> sendReply(ReplyRequestDto dto) {
         Feedback feedback = feedbackRepository.findById(dto.id()).orElseThrow(() -> new EntityNotFoundException("존재하지 않는 VOC"));
         try {
+            feedback.updateFeedback("T", dto.text());
             emailService.sendReplyEmail(feedback.getEmail(), feedback.getFeedback(), dto.text());
         } catch (MessagingException exception){
             return ResponseEntity.badRequest().body(ApiResponseWrapper.fail("메일 전송 실패"));
         }
-        feedback.updateFeedback("T", dto.text());
         return ResponseEntity.ok(ApiResponseWrapper.success());
     }
 }

--- a/src/main/java/fotcamp/finhub/common/domain/Member.java
+++ b/src/main/java/fotcamp/finhub/common/domain/Member.java
@@ -25,17 +25,20 @@ public class Member {
     @JoinColumn(name = "USERTYPE_ID")
     private UserType userType;
 
-    @Column(name = "EMAIL", nullable = false)
+    @Column(name = "EMAIL") // apple 로그인시, 이메일 nullable
     private String email;
 
     @Column(name = "PROFILE_NICKNAME")
-    private String name;
+    private String name; // 소셜 로그인시, 저장될 이름 (apple 로그인 - null 저장)
 
-    private String nickname;
+    private String nickname; // 앱 내에서 사용될 이름 (유저가 설정)
     private boolean pushYn;
     private String fcmToken;
     private LocalDateTime fcmTokenCreatedAt;
-    private String provider; // OAuth 가입 방법 ( google , kakao )
+    private String provider; // OAuth 가입 방법 ( google , kakao, apple )
+
+    @Column(name = "MEMBER_UUID")
+    private String memberUuid; // 소셜 로그인시, 저장될 멤버 고유식별자값
 
     @Enumerated(EnumType.STRING)
     @Column(name = "ROLE", nullable = false)
@@ -66,11 +69,12 @@ public class Member {
     @OneToOne(mappedBy = "member", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private RefreshToken refreshToken;
 
-    public Member(String email, String name, String provider){
+    public Member(String email, String name, String provider, String memberUuid){
         this.email = email;
         this.name = name;
         this.provider = provider;
         this.role = RoleType.ROLE_USER;
+        this.memberUuid = memberUuid;
     }
 
     public void updateFcmToken(String fcmToken){
@@ -131,5 +135,8 @@ public class Member {
     public void removeFcmToken() {
         this.fcmToken = null;
         this.fcmTokenCreatedAt = null;
+    }
+    public void updateMemberUuid(String uuid){
+        this.memberUuid = uuid;
     }
 }

--- a/src/main/java/fotcamp/finhub/common/security/CustomUserDetailService.java
+++ b/src/main/java/fotcamp/finhub/common/security/CustomUserDetailService.java
@@ -23,15 +23,16 @@ public class CustomUserDetailService implements UserDetailsService {
 
 
     @Override
-    public CustomUserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException{
-        Member member = memberRepository.findById(Long.parseLong(memberId))
+    public CustomUserDetails loadUserByUsername(String uuid) throws UsernameNotFoundException{
+        Member member = memberRepository.findByMemberUuid(uuid)
                 .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저가 없습니다."));
         CustomUserInfo dto = modelMapper.map(member, CustomUserInfo.class);
+        System.out.println(dto.getUuid()+"******************************8");
         return new CustomUserDetails(dto);
     }
 
-    public CustomUserDetails loadAdminByRole(String adminId) throws UsernameNotFoundException{
-        Manager manager = managerRepository.findById(Long.parseLong(adminId)).orElseThrow(
+    public CustomUserDetails loadAdminByRole(String uuid) throws UsernameNotFoundException{
+        Manager manager = managerRepository.findByManagerUuid(uuid).orElseThrow(
                 () -> new UsernameNotFoundException("해당하는 관리자가 없습니다."));
         CustomUserInfo dto = modelMapper.map(manager, CustomUserInfo.class);
         return new CustomUserDetails(dto);

--- a/src/main/java/fotcamp/finhub/common/security/CustomUserDetails.java
+++ b/src/main/java/fotcamp/finhub/common/security/CustomUserDetails.java
@@ -34,7 +34,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getMemberId().toString();
+        return user.getUuid();
     }
 
     @Override

--- a/src/main/java/fotcamp/finhub/common/security/CustomUserInfo.java
+++ b/src/main/java/fotcamp/finhub/common/security/CustomUserInfo.java
@@ -15,23 +15,25 @@ import lombok.Setter;
 public class CustomUserInfo {
 
     private Long memberId;
+    private String uuid;
     private String email;
     private String name;
     private RoleType role;
 
 
-    public CustomUserInfo(Long memberId, String email, String name, RoleType role) {
+    public CustomUserInfo(Long memberId, String uuid, String email, String name, RoleType role) {
         this.memberId = memberId;
+        this.uuid = uuid;
         this.email = email;
         this.name = name;
         this.role = role;
     }
 
-    public static CustomUserInfo fromEntity(Member member){
-        return CustomUserInfo.builder()
-                .email(member.getEmail())
-                .name(member.getName())
-                .role(member.getRole())
-                .build();
-    }
+//    public static CustomUserInfo fromEntity(Member member){
+//        return CustomUserInfo.builder()
+//                .email(member.getEmail())
+//                .name(member.getName())
+//                .role(member.getRole())
+//                .build();
+//    }
 }

--- a/src/main/java/fotcamp/finhub/common/security/JwtAuthFilter.java
+++ b/src/main/java/fotcamp/finhub/common/security/JwtAuthFilter.java
@@ -2,9 +2,6 @@ package fotcamp.finhub.common.security;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import fotcamp.finhub.common.api.ApiStatus;
-import fotcamp.finhub.common.dto.response.ErrorMessageResponseDto;
-import fotcamp.finhub.common.exception.ErrorMessage;
 import fotcamp.finhub.common.utils.JwtUtil;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,9 +41,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         String token = jwtUtil.resolveToken(request);
         if (token != null && !token.isEmpty() && jwtUtil.validateToken(token)) {
-            Long memberId = jwtUtil.getUserId(token);
+            String uuid = jwtUtil.getUuid(token);
             String roleType = jwtUtil.getRoleType(token);
-            CustomUserDetails userDetails = loadUserDetailsByRole(roleType, memberId);
+            CustomUserDetails userDetails = loadUserDetailsByRole(roleType, uuid);
             if (userDetails != null) {
                 UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(auth);
@@ -55,11 +52,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         chain.doFilter(request, response);
     }
 
-    private CustomUserDetails loadUserDetailsByRole(String roleType, Long memberId) {
+    private CustomUserDetails loadUserDetailsByRole(String roleType, String uuid) {
         if ("ROLE_USER".equals(roleType)) {
-            return customUserDetailService.loadUserByUsername(memberId.toString());
+            return customUserDetailService.loadUserByUsername(uuid);
         } else {
-            return customUserDetailService.loadAdminByRole(memberId.toString());
+            return customUserDetailService.loadAdminByRole(uuid);
         }
     }
 }

--- a/src/main/java/fotcamp/finhub/common/utils/JwtUtil.java
+++ b/src/main/java/fotcamp/finhub/common/utils/JwtUtil.java
@@ -39,23 +39,23 @@ public class JwtUtil {
 
     /**
      * Access Token 생성
-     * @param memberId
+     * @param uuid, roleType, provider
      * @return TokenDto
      */
-    public TokenDto createAllTokens(Long memberId, String roleType, String provider){
-        return new TokenDto(createToken(memberId, roleType, "Access", provider), createToken(memberId,roleType, "Refresh", provider));
+    public TokenDto createAllTokens(String uuid, String roleType, String provider){
+        return new TokenDto(createToken(uuid, roleType, "Access", provider), createToken(uuid,roleType, "Refresh", provider));
     }
 
     /**
      * JWT 생성
-     * @param memberId, type
+     * @param uuid, roleType, type, provider
      * @return JWT String
      */
-    public String createToken(Long memberId, String roleType, String type, String provider){
+    public String createToken(String uuid, String roleType, String type, String provider){
         long expireTime = type.equals("Access") ? accessTokenExpTime : refreshTokenExpTime;
 
         Claims claims = Jwts.claims();
-        claims.put("memberId", memberId);
+        claims.put("uuid", uuid);
         claims.put("provider", provider);
         claims.put("role", roleType);
         ZonedDateTime now = ZonedDateTime.now();
@@ -70,12 +70,12 @@ public class JwtUtil {
     }
 
     /**
-     * 토큰에서 User ID 추출
+     * 토큰에서 UUID 추출
      * @param token
-     * @return User ID
+     * @return UUID
      * */
-    public Long getUserId(String token){
-        return parseClaims(token).get("memberId", Long.class);
+    public String getUuid(String token){ // 제공사 uuid값으로 전환, memberId는 위험하다고 판단
+        return parseClaims(token).get("uuid", String.class);
     }
 
     /**

--- a/src/main/java/fotcamp/finhub/main/config/GoogleConfig.java
+++ b/src/main/java/fotcamp/finhub/main/config/GoogleConfig.java
@@ -29,4 +29,7 @@ public class GoogleConfig {
     private String redirect_uri_beLocal;
     @Value("${custom-redirect-uri.google.beprod}")
     private String redirect_uri_beProd;
+    @Value("${custom-redirect-uri.google.bedev}")
+    private String redirect_uri_beDev;
+
 }

--- a/src/main/java/fotcamp/finhub/main/config/KakaoConfig.java
+++ b/src/main/java/fotcamp/finhub/main/config/KakaoConfig.java
@@ -30,5 +30,7 @@ public class KakaoConfig {
     private String redirect_uri_beLocal;
     @Value("${custom-redirect-uri.kakao.beprod}")
     private String redirect_uri_beProd;
+    @Value("${custom-redirect-uri.kakao.bedev}")
+    private String redirect_uri_beDev;
 
 }

--- a/src/main/java/fotcamp/finhub/main/controller/AuthApiController.java
+++ b/src/main/java/fotcamp/finhub/main/controller/AuthApiController.java
@@ -24,7 +24,7 @@ import java.text.ParseException;
     description = "액세스 토큰 받아오는 방법 \n\n" +
             "kakao 인가코드를 먼저 받아온다. \n\n" +
             "BE local Test : https://kauth.kakao.com/oauth/authorize?client_id=8cdab51912aa75e69f1dce7eb88d196c&redirect_uri=http://localhost:8090/api/v1/auth/login/oauth2/callback/kakao&response_type=code \n\n" +
-            "BE dev Test : https://kauth.kakao.com/oauth/authorize?client_id=8cdab51912aa75e69f1dce7eb88d196c&redirect_uri=http://15.164.149.101:3000/auth/kakao/callback&response_type=code \n\n" +
+            "BE dev Test : https://kauth.kakao.com/oauth/authorize?client_id=8cdab51912aa75e69f1dce7eb88d196c&redirect_uri=https://dev-api.fin-hub.co.kr/api/v1/auth/login/oauth2/callback/kakao&response_type=code \n\n" +
             "BE main Test : https://kauth.kakao.com/oauth/authorize?client_id=8cdab51912aa75e69f1dce7eb88d196c&redirect_uri=https://main.fin-hub.co.kr/api/v1/auth/login/oauth2/callback/kakao&response_type=code \n\n" +
             "\n\n"+
             "google 인가코드 받아오기 \n\n"+

--- a/src/main/java/fotcamp/finhub/main/controller/AuthApiController.java
+++ b/src/main/java/fotcamp/finhub/main/controller/AuthApiController.java
@@ -25,7 +25,7 @@ import java.text.ParseException;
             "kakao 인가코드를 먼저 받아온다. \n\n" +
             "BE local Test : https://kauth.kakao.com/oauth/authorize?client_id=8cdab51912aa75e69f1dce7eb88d196c&redirect_uri=http://localhost:8090/api/v1/auth/login/oauth2/callback/kakao&response_type=code \n\n" +
             "BE dev Test : https://kauth.kakao.com/oauth/authorize?client_id=8cdab51912aa75e69f1dce7eb88d196c&redirect_uri=http://15.164.149.101:3000/auth/kakao/callback&response_type=code \n\n" +
-            "BE main Test : https://kauth.kakao.com/oauth/authorize?client_id=8cdab51912aa75e69f1dce7eb88d196c&redirect_uri=https://main.fin-hub.co.kr/auth/kakao/callback&response_type=code \n\n" +
+            "BE main Test : https://kauth.kakao.com/oauth/authorize?client_id=8cdab51912aa75e69f1dce7eb88d196c&redirect_uri=https://main.fin-hub.co.kr/api/v1/auth/login/oauth2/callback/kakao&response_type=code \n\n" +
             "\n\n"+
             "google 인가코드 받아오기 \n\n"+
             "BE local : https://accounts.google.com/o/oauth2/v2/auth?client_id=353339464651-dnul84p5jsljqkg1gfsgsdoqol5ci1ak.apps.googleusercontent.com&redirect_uri=http://localhost:8090/api/v1/auth/login/oauth2/callback/google&response_type=code&scope=profile email \n\n"+

--- a/src/main/java/fotcamp/finhub/main/dto/process/login/KakaoUserInfoProcessDto.java
+++ b/src/main/java/fotcamp/finhub/main/dto/process/login/KakaoUserInfoProcessDto.java
@@ -12,6 +12,5 @@ public class KakaoUserInfoProcessDto {
 
     private String name;
     private String email;
-
-
+    private String uuid;
 }

--- a/src/main/java/fotcamp/finhub/main/repository/CommentsLikeRepository.java
+++ b/src/main/java/fotcamp/finhub/main/repository/CommentsLikeRepository.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 public interface CommentsLikeRepository extends JpaRepository<CommentsLike, Long> {
     Optional<CommentsLike> findFirstByCommentAndMember(Comments comment, Member member);
     List<CommentsLike> findByMember(Member member);
+    List<CommentsLike> findByComment(Comments comments);
 
     @Modifying
     @Query("DELETE FROM CommentsLike cl WHERE cl.comment = :comment")

--- a/src/main/java/fotcamp/finhub/main/repository/CommentsRepository.java
+++ b/src/main/java/fotcamp/finhub/main/repository/CommentsRepository.java
@@ -3,10 +3,7 @@ package fotcamp.finhub.main.repository;
 import fotcamp.finhub.common.domain.Comments;
 import fotcamp.finhub.common.domain.GptColumn;
 import fotcamp.finhub.common.domain.Member;
-import fotcamp.finhub.common.domain.QuitReasons;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,7 +16,7 @@ public interface CommentsRepository extends JpaRepository<Comments, Long> {
 
     Page<Comments> findByGptColumnAndUseYnOrderByCreatedTimeDesc
             (GptColumn gptColumn, String useYn,Pageable pageable);
-    Page<Comments> findByGptColumnAndUseYnOrderByTotalLikeDescCreatedTimeDesc
+    Page<Comments> findByGptColumnAndUseYnOrderByTotalLikeDesc
             (GptColumn gptColumn, String useYn, Pageable pageable);
     Page<Comments> findByGptColumnAndUseYnAndMemberNotInOrderByCreatedTimeDesc
             (GptColumn gptColumn, String useYn, List<Member> blockedMemberIds,Pageable pageable); // 최신순

--- a/src/main/java/fotcamp/finhub/main/repository/MemberRepository.java
+++ b/src/main/java/fotcamp/finhub/main/repository/MemberRepository.java
@@ -12,8 +12,9 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-
     Optional<Member> findByEmailAndProvider(String email, String provider);
+    Optional<Member> findByMemberUuid(String uuid);
+
     List<Member> findByCalendarEmoticon(CalendarEmoticon calendarEmoticon);
     boolean existsByNickname(String nickname);
 

--- a/src/main/java/fotcamp/finhub/main/service/AuthService2.java
+++ b/src/main/java/fotcamp/finhub/main/service/AuthService2.java
@@ -123,6 +123,8 @@ public class AuthService2 {
                 return kakaoConfig.getRedirect_uri_beLocal();
             case "beprod":
                 return kakaoConfig.getRedirect_uri_beProd();
+            case "bedev" :
+                return kakaoConfig.getRedirect_uri_beDev();
             default:
                 return kakaoConfig.getRedirect_uri_feLocal();
         }
@@ -208,6 +210,8 @@ public class AuthService2 {
                 return googleConfig.getRedirect_uri_beLocal();
             case "beprod":
                 return googleConfig.getRedirect_uri_beProd();
+            case "bedev":
+                return googleConfig.getRedirect_uri_beDev();
             default:
                 return googleConfig.getRedirect_uri_feLocal();
         }

--- a/src/main/java/fotcamp/finhub/main/service/AuthService2.java
+++ b/src/main/java/fotcamp/finhub/main/service/AuthService2.java
@@ -86,7 +86,7 @@ public class AuthService2 {
         String uuid = kakaoUserInfo.getUuid(); // 카카오 고유식별자 값
         String provider = kakaoConfig.getClient_name();
         AtomicBoolean isMember = new AtomicBoolean(true); // AtomicBoolean을 사용하여 isMember를 람다 내부에서 수정할 수 있도록 설정 ( 기존 유저가 자주 조회할 것으로 예상하여 디폴트는 true)
-        Member member = memberRepository.findByEmailAndProvider(email, provider)
+        Member member = memberRepository.findByMemberUuid(uuid)
                 .orElseGet(() -> {
                     isMember.set(false); // 신규회원
                     return memberRepository.save(new Member(email, name, provider, uuid)); // email, name은 null이어도 무관
@@ -170,7 +170,7 @@ public class AuthService2 {
         String sub = (String) userInfo.get("sub");
         String provider = googleConfig.getClient_name();
         AtomicBoolean isMember = new AtomicBoolean(true);
-        Member member = memberRepository.findByEmailAndProvider(email, provider)
+        Member member = memberRepository.findByMemberUuid(sub)
                 .orElseGet(() -> {
                     isMember.set(false); // 신규회원
                     return memberRepository.save(new Member(email, name, provider, sub));

--- a/src/main/java/fotcamp/finhub/main/service/AuthService2.java
+++ b/src/main/java/fotcamp/finhub/main/service/AuthService2.java
@@ -56,6 +56,7 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -82,16 +83,20 @@ public class AuthService2 {
         KakaoUserInfoProcessDto kakaoUserInfo = getKakaoUserInfo(kakaoAccessToken);
         String email = kakaoUserInfo.getEmail();
         String name = kakaoUserInfo.getName();
+        String uuid = kakaoUserInfo.getUuid(); // 카카오 고유식별자 값
         String provider = kakaoConfig.getClient_name();
-        AtomicBoolean isMember = new AtomicBoolean(true); // AtomicBoolean을 사용하여 isNewMember를 람다 내부에서 수정할 수 있도록 설정 ( 기존 유저가 자주 조회할 것으로 예상하여 디폴트는 true)
+        AtomicBoolean isMember = new AtomicBoolean(true); // AtomicBoolean을 사용하여 isMember를 람다 내부에서 수정할 수 있도록 설정 ( 기존 유저가 자주 조회할 것으로 예상하여 디폴트는 true)
         Member member = memberRepository.findByEmailAndProvider(email, provider)
                 .orElseGet(() -> {
                     isMember.set(false); // 신규회원
-                    return memberRepository.save(new Member(email, name, provider));
+                    return memberRepository.save(new Member(email, name, provider, uuid)); // email, name은 null이어도 무관
                 });
-        TokenDto allTokens = jwtUtil.createAllTokens(member.getMemberId(), member.getRole().toString(), member.getProvider());
+        if(!Objects.equals(member.getMemberUuid(), uuid)){ // 제공사 고유식별자 값이 존재하지 않았거나 수정된 경우, 최신 uuid 업데이트
+            member.updateMemberUuid(uuid);
+        }
+        TokenDto allTokens = jwtUtil.createAllTokens(member.getMemberUuid(), member.getRole().toString(), member.getProvider());
         saveOrUpdateRefreshToken(member, allTokens.getRefreshToken());
-        // 응답 데이터 생성: 닉네임, 이메일, 유저아바타 이미지, 직업명, 직업아바타이미지, 푸시알림 정보
+        // 응답 데이터 생성: 닉네임, 이메일, 유저아바타 이미지, 직업명, 직업아바타이미지, 푸시알림 정보, 기존회원유무
         UserInfoProcessDto userInfoProcessDto = createUserInfoProcessDto(member, isMember);
         LoginResponseDto loginResponseDto = new LoginResponseDto(allTokens, userInfoProcessDto);
         return ResponseEntity.ok(ApiResponseWrapper.success(loginResponseDto));
@@ -142,7 +147,7 @@ public class AuthService2 {
         String id = jsonNode.get("id").asText(); // 카카오 고유식별자
         String nickname = jsonNode.get("properties").get("nickname").asText();
         String email = jsonNode.get("kakao_account").get("email").asText();
-        return new KakaoUserInfoProcessDto(nickname, email);
+        return new KakaoUserInfoProcessDto(nickname, email, id);
     }
 
     private UserInfoProcessDto createUserInfoProcessDto(Member member, AtomicBoolean isMember) {
@@ -168,9 +173,12 @@ public class AuthService2 {
         Member member = memberRepository.findByEmailAndProvider(email, provider)
                 .orElseGet(() -> {
                     isMember.set(false); // 신규회원
-                    return memberRepository.save(new Member(email, name, provider));
+                    return memberRepository.save(new Member(email, name, provider, sub));
                 });
-        TokenDto allTokens = jwtUtil.createAllTokens(member.getMemberId(), member.getRole().toString(), provider);
+        if(!Objects.equals(member.getMemberUuid(), sub)){ // 제공사 고유식별자 값이 존재하지 않았거나 수정된 경우, 최신 uuid 업데이트
+            member.updateMemberUuid(sub);
+        }
+        TokenDto allTokens = jwtUtil.createAllTokens(member.getMemberUuid(), member.getRole().toString(), provider);
         saveOrUpdateRefreshToken(member, allTokens.getRefreshToken());
         UserInfoProcessDto userInfoProcessDto = createUserInfoProcessDto(member, isMember);
         LoginResponseDto loginResponseDto = new LoginResponseDto(allTokens, userInfoProcessDto);
@@ -217,14 +225,16 @@ public class AuthService2 {
         String sub = claims.getSubject();
         String provider = appleConfig.getClient_name();
         AtomicBoolean isMember = new AtomicBoolean(true);
-        Member member = memberRepository.findByEmailAndProvider(email, provider)
+        Member member = memberRepository.findByMemberUuid(sub)
                 .orElseGet(() -> {
                     isMember.set(false); // 신규회원
-                    return memberRepository.save(new Member(email, name, provider));
+                    return memberRepository.save(new Member(email, name, provider, sub));
                 });
-        TokenDto allTokens = jwtUtil.createAllTokens(member.getMemberId(), member.getRole().toString(), provider);
+        if(!Objects.equals(member.getMemberUuid(), sub)){ // 제공사 고유식별자 값이 존재하지 않았거나 수정된 경우, 최신 uuid 업데이트
+            member.updateMemberUuid(sub);
+        }
+        TokenDto allTokens = jwtUtil.createAllTokens(member.getMemberUuid(), member.getRole().toString(), provider);
         saveOrUpdateRefreshToken(member, allTokens.getRefreshToken());
-        System.out.println(isMember + "*******************************");
         UserInfoProcessDto userInfoProcessDto = createUserInfoProcessDto(member, isMember);
         LoginResponseDto loginResponseDto = new LoginResponseDto(allTokens, userInfoProcessDto);
         return ResponseEntity.ok(ApiResponseWrapper.success(loginResponseDto));
@@ -307,10 +317,10 @@ public class AuthService2 {
     public ResponseEntity<ApiResponseWrapper> validRefreshToken(HttpServletRequest request){
         String refreshToken = request.getHeader("refreshToken");
         if(refreshToken!= null && jwtUtil.validateToken(refreshToken)){
-            Long memberId = jwtUtil.getUserId(refreshToken);
+            String uuid = jwtUtil.getUuid(refreshToken);
             String  roleType = jwtUtil.getRoleType(refreshToken);
             String provider = jwtUtil.getProvider(refreshToken);
-            String newAccessToken = jwtUtil.createToken(memberId, roleType,"Access", provider);
+            String newAccessToken = jwtUtil.createToken(uuid, roleType,"Access", provider);
             UpdateAccessTokenResponseDto updateAccessTokenResponseDto = new UpdateAccessTokenResponseDto(newAccessToken);
             return ResponseEntity.ok(ApiResponseWrapper.success(updateAccessTokenResponseDto));
         }
@@ -326,16 +336,16 @@ public class AuthService2 {
 
         if(jwtUtil.validateTokenServiceLayer(accessToken)){
             // 액세스토큰 유효할 때
-            Long memberId = jwtUtil.getUserId(accessToken);
-            Member member = memberRepository.findById(memberId).orElseThrow(
+            String uuid = jwtUtil.getUuid(accessToken);
+            Member member = memberRepository.findByMemberUuid(uuid).orElseThrow(
                     () -> new EntityNotFoundException("MEMBER ID가 존재하지 않습니다."));
             LoginResponseDto loginResponseDto = updatingLoginResponse(member);
             return ResponseEntity.ok(ApiResponseWrapper.success(loginResponseDto));
         }
         if (jwtUtil.validateTokenServiceLayer(refreshToken)) {
             // 액세스토큰 유효x, 리프레시토큰 유효할 때
-            Long memberId = jwtUtil.getUserId(refreshToken);
-            Member member = memberRepository.findById(memberId).orElseThrow(
+            String uuid = jwtUtil.getUuid(refreshToken);
+            Member member = memberRepository.findByMemberUuid(uuid).orElseThrow(
                     () -> new EntityNotFoundException("MEMBER ID가 존재하지 않습니다."));
             LoginResponseDto loginResponseDto = updatingLoginResponse(member);
             return ResponseEntity.ok(ApiResponseWrapper.success(loginResponseDto));
@@ -344,7 +354,7 @@ public class AuthService2 {
     }
 
     public LoginResponseDto updatingLoginResponse(Member member){
-        TokenDto allTokens = jwtUtil.createAllTokens(member.getMemberId(), member.getRole().toString(), member.getProvider());
+        TokenDto allTokens = jwtUtil.createAllTokens(member.getMemberUuid(), member.getRole().toString(), member.getProvider());
         Optional<RefreshToken> existingRefreshToken = tokenRepository.findByMember(member);
         if (existingRefreshToken.isPresent()) {
             // 기존 리프레시 토큰 정보가 있는 경우, 새 리프레시 토큰으로 업데이트

--- a/src/main/java/fotcamp/finhub/main/service/ColumnService.java
+++ b/src/main/java/fotcamp/finhub/main/service/ColumnService.java
@@ -169,9 +169,9 @@ public class ColumnService {
 
         if (blockMemberList.isEmpty()) {
             if (type == 1) { // 인기순
-                commentsList = commentsRepository.findByGptColumnAndUseYnOrderByCreatedTimeDesc(gptColumn, "Y", pageable);
+                commentsList = commentsRepository.findByGptColumnAndUseYnOrderByTotalLikeDesc(gptColumn, "Y", pageable);
             } else if (type == 2) { // 최신순
-                commentsList = commentsRepository.findByGptColumnAndUseYnOrderByTotalLikeDescCreatedTimeDesc(gptColumn, "Y", pageable);
+                commentsList = commentsRepository.findByGptColumnAndUseYnOrderByCreatedTimeDesc(gptColumn, "Y", pageable);
             } else {
                 return ResponseEntity.ok(ApiResponseWrapper.fail("type을 확인해주세요", type));
             }

--- a/src/main/java/fotcamp/finhub/main/service/MainService.java
+++ b/src/main/java/fotcamp/finhub/main/service/MainService.java
@@ -146,11 +146,19 @@ public class MainService {
                 .reason(dto.reason())
                 .build();
         quitMemberRepository.save(quitMember);
-        // 댓글 좋아요 기록 삭제
-        List<CommentsLike> commentsLikeAll = commentsLikeRepository.findByMember(existingMember);
-        commentsLikeRepository.deleteAll(commentsLikeAll);
-        // 댓글 삭제
+        // 멤버가 작성한 모든 댓글 조회
         List<Comments> commentAll = commentsRepository.findByMember(existingMember);
+        // 각 댓글에 타인이 눌렀던 좋아요 기록 삭제
+        for (Comments comment : commentAll) {
+            List<CommentsLike> commentsLikeAll = commentsLikeRepository.findByComment(comment);
+            commentsLikeRepository.deleteAll(commentsLikeAll);
+        }
+
+        // 해당 멤버가 누른 좋아요 기록 삭제
+        List<CommentsLike> userCommentsLikes = commentsLikeRepository.findByMember(existingMember);
+        commentsLikeRepository.deleteAll(userCommentsLikes);
+
+        // 댓글 삭제
         commentsRepository.deleteAll(commentAll);
 
         // 컬럼 스크랩 삭제


### PR DESCRIPTION
## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [x] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] 정기반영
- [ ] ETC

## 📝 PR 설명

<!-- PR 설명 -->

## 관련된 이슈 넘버
#317 

<!-- close #1 -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- member entity, admin entity uuid 필드 추가
- uuid 필드 업데이트 로직 추가
- apple login의 경우 nullable한 이메일을 처리할 findByMemberUuid() 메소드 대체
- jwt 생성시, uuid 클레임 추가 및 memberId 클레임 제거
- 세가지 소셜로그인 로컬테스트 완료, 발급된 토큰 바탕으로 일부 메소드 테스트 진행.
- 현재 admin은 플랫폼 로그인 프로세스와 동일한 상황, db에 수기로 고유 uuid 주입 필요

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
