### PR TITLE
[131] Admin) 칼럼 댓글 관리 #2

### DIFF
--- a/src/main/java/fotcamp/finhub/admin/controller/AdminController.java
+++ b/src/main/java/fotcamp/finhub/admin/controller/AdminController.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import fotcamp.finhub.admin.dto.request.*;
 import fotcamp.finhub.admin.service.AdminService;
 import fotcamp.finhub.admin.service.FcmService;
+import fotcamp.finhub.common.api.ApiCommonResponse;
 import fotcamp.finhub.common.api.ApiResponseWrapper;
 import fotcamp.finhub.common.security.CustomUserDetails;
 import fotcamp.finhub.common.utils.PageableUtil;
 import fotcamp.finhub.main.dto.response.column.ReportCommentRequestDto;
+import fotcamp.finhub.main.dto.response.column.ReportedCommentsResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -487,9 +489,9 @@ public class AdminController {
     @GetMapping("/report/comment")
     @PreAuthorize("hasRole('SUPER') or hasRole('BE') or hasRole('FE')")
     @Operation(summary = "신고된 댓글 보기", description = "신고된 댓글 조회 ")
-    public ResponseEntity<ApiResponseWrapper> getReportedComment(@RequestParam(value = "page", defaultValue = "1") int page,
-                                                                 @RequestParam(value = "size", defaultValue = "10") int size,
-                                                                 @RequestParam(name = "useYN", required = false) String useYN
+    public ResponseEntity<ApiCommonResponse<ReportedCommentsResponseDto>> getReportedComment(@RequestParam(value = "page", defaultValue = "1") int page,
+                                                                                             @RequestParam(value = "size", defaultValue = "10") int size,
+                                                                                             @RequestParam(name = "useYN", required = false) String useYN
     ) {
         Pageable pageable = PageableUtil.createPageableWithDefaultSort(page, size, "id");
         return adminService.getReportedComment(pageable, useYN);

--- a/src/main/java/fotcamp/finhub/admin/service/AdminService.java
+++ b/src/main/java/fotcamp/finhub/admin/service/AdminService.java
@@ -10,6 +10,7 @@ import fotcamp.finhub.admin.dto.request.*;
 import fotcamp.finhub.admin.dto.response.*;
 import fotcamp.finhub.admin.repository.*;
 import fotcamp.finhub.admin.service.gpt.GptService;
+import fotcamp.finhub.common.api.ApiCommonResponse;
 import fotcamp.finhub.common.api.ApiResponseWrapper;
 import fotcamp.finhub.common.domain.*;
 import fotcamp.finhub.common.dto.process.PageInfoProcessDto;
@@ -1219,22 +1220,26 @@ public class AdminService {
         return ResponseEntity.ok(ApiResponseWrapper.success(detail));
     }
 
-    // 신고된 댓글 보기
-    public ResponseEntity<ApiResponseWrapper> getReportedComment(Pageable pageable, String useYN) {
+    /**
+     * 신고된 댓글내역 조회
+     * */
+    public ResponseEntity<ApiCommonResponse<ReportedCommentsResponseDto>> getReportedComment(Pageable pageable, String useYN) {
         Page<CommentsReport> commentsReports = commentsReportRepositoryCustom.searchAllTCommentsReportFilterList(pageable, useYN);
         List<ReportedCommentsProcessDto> reportedCommentsProcessDtoList = commentsReports.getContent().stream().map(ReportedCommentsProcessDto::new).toList();
         PageInfoProcessDto PageInfoProcessDto = commonService.setPageInfo(commentsReports);
         ReportedCommentsResponseDto allTopicRequestResponseDto = new ReportedCommentsResponseDto(reportedCommentsProcessDtoList, PageInfoProcessDto);
 
-        return ResponseEntity.ok(ApiResponseWrapper.success(allTopicRequestResponseDto));
+        return ResponseEntity.ok(ApiCommonResponse.success(allTopicRequestResponseDto));
     }
 
-    // 신고된 댓글 처리
+    /**
+     * 신고된 댓글 처리
+     * */
     public ResponseEntity<ApiResponseWrapper> postReportedComment(ReportCommentRequestDto dto) {
         Comments comment = commentsRepository.findById(dto.id()).orElseThrow(() -> new EntityNotFoundException("신고된 comments ID가 없습니다."));
         CommentsReport commentsReport = commentsReportRepository.findByReportedComment(comment).orElseThrow(() -> new EntityNotFoundException("신고된 commentsReport ID가 없습니다."));
-        comment.modifyUseYn(); // 무조건 n으로
-        commentsReport.report();
+        comment.disabled();
+        commentsReport.processReport();
         return ResponseEntity.ok(ApiResponseWrapper.success());
     }
 

--- a/src/main/java/fotcamp/finhub/common/api/ApiCommonResponse.java
+++ b/src/main/java/fotcamp/finhub/common/api/ApiCommonResponse.java
@@ -1,0 +1,22 @@
+package fotcamp.finhub.common.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiCommonResponse<T>(
+        ApiStatus status,
+        String errorMsg,
+        T data
+) {
+    public static <T> ApiCommonResponse<T> success() {
+        return new ApiCommonResponse<>(ApiStatus.SUCCESS, null, null);
+    }
+
+    public static <T> ApiCommonResponse<T> success(T data) {
+        return new <T>  ApiCommonResponse<T> (ApiStatus.SUCCESS, null, data);
+    }
+
+    public static <T> ApiCommonResponse<T>  fail(String errorMsg) {
+        return new ApiCommonResponse<>(ApiStatus.FAIL, errorMsg, null);
+    }
+}

--- a/src/main/java/fotcamp/finhub/common/domain/Comments.java
+++ b/src/main/java/fotcamp/finhub/common/domain/Comments.java
@@ -46,15 +46,7 @@ public class Comments extends BaseEntity{
         this.content = content;
     }
 
-    public void modifyUseYn() {
+    public void disabled() {
         this.useYn = "N";
-    }
-
-    public void useYnUpdate() {
-        if ("Y".equals(this.useYn)) {
-            this.useYn = "N";
-        } else if ("N".equals(this.useYn)) {
-            this.useYn = "Y";
-        }
     }
 }

--- a/src/main/java/fotcamp/finhub/common/domain/CommentsReport.java
+++ b/src/main/java/fotcamp/finhub/common/domain/CommentsReport.java
@@ -35,7 +35,7 @@ public class CommentsReport extends BaseEntity{
         this.useYn = "N";
     }
 
-    public void report(){
+    public void processReport(){
         this.useYn = "Y";
     }
 }

--- a/src/main/java/fotcamp/finhub/main/dto/process/ReportedCommentsProcessDto.java
+++ b/src/main/java/fotcamp/finhub/main/dto/process/ReportedCommentsProcessDto.java
@@ -2,18 +2,36 @@ package fotcamp.finhub.main.dto.process;
 
 import fotcamp.finhub.common.domain.CommentsReport;
 import fotcamp.finhub.common.domain.TopicRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Schema(description = "댓글신고정보 DTO")
 public class ReportedCommentsProcessDto {
+    @Schema(description = "신고처리id")
     private final Long id;
+
+    @Schema(description = "댓글id")
     private final Long commentId;
+
+    @Schema(description = "댓글내용")
     private final String comment;
+
+    @Schema(description = "신고사유")
     private final String reason;
+
+    @Schema(description = "댓글사용여부", examples = {"Y", "N"})
     private final String useYn;
+
+    @Schema(description = "신고처리여부", examples = {"Y", "N"})
+    private final String isProcessed;
+
+    @Schema(description = "신고된유저닉네임")
     private final String reportedNickname;
+
+    @Schema(description = "신고힌유저닉네임")
     private final String reporterNickname;
 
     public ReportedCommentsProcessDto(CommentsReport commentsReport) {
@@ -21,7 +39,8 @@ public class ReportedCommentsProcessDto {
         this.commentId = commentsReport.getReportedComment().getId();
         this.comment = commentsReport.getReportedComment().getContent();
         this.reason = commentsReport.getReportReasons().getReason();
-        this.useYn = commentsReport.getUseYn();
+        this.useYn = commentsReport.getReportedComment().getUseYn();
+        this.isProcessed = commentsReport.getUseYn();
         this.reportedNickname = commentsReport.getReportedMember().getNickname();
         this.reporterNickname = commentsReport.getReporterMember().getNickname();
     }

--- a/src/main/java/fotcamp/finhub/main/service/ColumnService.java
+++ b/src/main/java/fotcamp/finhub/main/service/ColumnService.java
@@ -236,7 +236,7 @@ public class ColumnService {
         if ("N".equals(comments.getUseYn())) {
             return ResponseEntity.ok(ApiResponseWrapper.fail("이미 삭제한 댓글입니다."));
         }
-        comments.modifyUseYn(); // 삭제처리 -> useYN "N"
+        comments.disabled();
 
         if (commentsReportRepository.findByReportedComment(comments).isPresent()) { // 이미 신고된 댓글 이였을 경우 싱크 맞추기 위해 N 처리
             CommentsReport commentsReport = commentsReportRepository.findByReportedComment(comments).get();


### PR DESCRIPTION
- 댓글신고내역조회 시, 댓글사용여부, 댓글신고처리여부 모두 반환하도록 수정
- 해당 api에 한해 ApiResponseWrapper를 ApiCommonResponse 로 교체 ==> swagger에서 dto정보를 api에서 바로 조회가능하도록 하기 위함

## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] 정기반영
- [ ] ETC

## 📝 PR 설명

<!-- PR 설명 -->

## 관련된 이슈 넘버

<!-- close #1 -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- 작업1

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
