### PR TITLE
[158] MAIN) 비로그인 유저 VOC 슬랙 알람 누락 해결 #1

### DIFF
--- a/src/main/java/fotcamp/finhub/main/service/MainService.java
+++ b/src/main/java/fotcamp/finhub/main/service/MainService.java
@@ -670,8 +670,8 @@ public class MainService {
                             .build())
                     .build();
             fcmService.sendFcmNotifications(pushProcessDto);
-            slackService.sendMsg(dto.getEmail(), dto.getText(), newVoc.getId());
         }
+        slackService.sendMsg(dto.getEmail(), dto.getText(), newVoc.getId());
         return ResponseEntity.ok(ApiResponseWrapper.success());
     }
 


### PR DESCRIPTION
- 로그인 유저의 VOC만 슬랙 알람으로 전송되던 것에서 비로그인 유저의 VOC도 슬랙 알람으로 전송되게 확장

## 📝 PR 유형

- [ ] 🚀 feature 기능 추가
- [ ] 🐞 버그 발생
- [ ] 🔨 리팩토링
- [ ] 📋 문서작성
- [ ] 🌍 빌드 설정 및 문제
- [ ] 정기반영
- [ ] ETC

## 📝 PR 설명

<!-- PR 설명 -->

## 관련된 이슈 넘버
FIN-158
<!-- close #1 -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->

- 비로그인 유저 VOC 슬랙 알람 누락 해결

## MR하기 전에 확인해주세요

- [ ] local code lint 검사를 진행하셨나요?
- [ ] loca ci test를 진행하셨나요?

## 📚 논의사항

<!-- 이 PR에서 더 논의할 사항 혹은 리뷰어에게 확인 요청하고 싶은 부분 기재 -->

## 📚 ETC

<!-- Screenshot, References 기재 -->
